### PR TITLE
Add more normalization to temporary directory

### DIFF
--- a/lib/rex/exploitation/cmdstager/bourne.rb
+++ b/lib/rex/exploitation/cmdstager/bourne.rb
@@ -18,6 +18,8 @@ class CmdStagerBourne < CmdStagerBase
 
   def generate(opts = {})
     opts[:temp] = opts[:temp] || '/tmp/'
+    opts[:temp] = opts[:temp].empty?? opts[:temp] : opts[:temp] + '/'
+    opts[:temp] = opts[:temp].gsub(/\/{2,}/, '/')
     opts[:temp] = opts[:temp].gsub(/'/, "\\\\'")
     opts[:temp] = opts[:temp].gsub(/ /, "\\ ")
     if (opts[:file])


### PR DESCRIPTION
This fixes #6238 when ```opts[:temp]``` doesn't contain a trailing slash. Also removes duplicate slashes.